### PR TITLE
feat: support donating to the pool

### DIFF
--- a/contracts/hub/schema/execute_msg.json
+++ b/contracts/hub/schema/execute_msg.json
@@ -37,6 +37,19 @@
       "additionalProperties": false
     },
     {
+      "description": "Donates specified amount of Luna to pool",
+      "type": "object",
+      "required": [
+        "donate"
+      ],
+      "properties": {
+        "donate": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
       "description": "Withdraw Luna that have finished unbonding in previous batches",
       "type": "object",
       "required": [

--- a/contracts/hub/src/contract.rs
+++ b/contracts/hub/src/contract.rs
@@ -34,7 +34,11 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> S
             env,
             receiver.map(|s| api.addr_validate(&s)).transpose()?.unwrap_or(info.sender),
             parse_received_fund(&info.funds, "uluna")?,
+            false,
         ),
+        ExecuteMsg::Donate {} => {
+            execute::bond(deps, env, info.sender, parse_received_fund(&info.funds, "uluna")?, true)
+        },
         ExecuteMsg::WithdrawUnbonded {
             receiver,
         } => execute::withdraw_unbonded(

--- a/contracts/hub/src/testing/tests.rs
+++ b/contracts/hub/src/testing/tests.rs
@@ -254,6 +254,100 @@ fn bonding() {
 }
 
 #[test]
+fn donating() {
+    let mut deps = setup_test();
+
+    // Bond when no delegation has been made
+    // In this case, the full deposit simply goes to the first validator
+    let res = execute(
+        deps.as_mut(),
+        mock_env(),
+        mock_info("user_1", &[Coin::new(1000000, "uluna")]),
+        ExecuteMsg::Bond {
+            receiver: None,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(res.messages.len(), 2);
+    assert_eq!(
+        res.messages[0],
+        SubMsg::reply_on_success(Delegation::new("alice", 1000000).to_cosmos_msg(), 2)
+    );
+    assert_eq!(
+        res.messages[1],
+        SubMsg {
+            id: 0,
+            msg: CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: "stake_token".to_string(),
+                msg: to_binary(&Cw20ExecuteMsg::Mint {
+                    recipient: "user_1".to_string(),
+                    amount: Uint128::new(1000000)
+                })
+                .unwrap(),
+                funds: vec![]
+            }),
+            gas_limit: None,
+            reply_on: ReplyOn::Never,
+        }
+    );
+
+    // Bond when there are existing delegations, and Luna:Stake exchange rate is >1
+    // Previously user 1 delegated 1,000,000 uluna. We assume we have accumulated 2.5% yield at 1025000 staked
+    deps.querier.set_staking_delegations(&[
+        Delegation::new("alice", 341667),
+        Delegation::new("bob", 341667),
+        Delegation::new("charlie", 341666),
+    ]);
+    deps.querier.set_cw20_total_supply("stake_token", 1000000);
+
+    let res: StateResponse = query_helper(deps.as_ref(), QueryMsg::State {});
+    assert_eq!(
+        res,
+        StateResponse {
+            total_ustake: Uint128::new(1000000),
+            total_uluna: Uint128::new(1025000),
+            exchange_rate: Decimal::from_ratio(1025000u128, 1000000u128),
+            unlocked_coins: vec![],
+        }
+    );
+
+    // Charlie has the smallest amount of delegation, so the full deposit goes to him
+    let res = execute(
+        deps.as_mut(),
+        mock_env(),
+        mock_info("user_2", &[Coin::new(12345, "uluna")]),
+        ExecuteMsg::Donate {},
+    )
+    .unwrap();
+
+    assert_eq!(res.messages.len(), 1);
+    assert_eq!(
+        res.messages[0],
+        SubMsg::reply_on_success(Delegation::new("charlie", 12345).to_cosmos_msg(), 2)
+    );
+
+    // Check the state after bonding
+    deps.querier.set_staking_delegations(&[
+        Delegation::new("alice", 341667),
+        Delegation::new("bob", 341667),
+        Delegation::new("charlie", 354011),
+    ]);
+
+    // nothing has been minted -> ustake stays the same, only uluna and exchange rate is changing.
+    let res: StateResponse = query_helper(deps.as_ref(), QueryMsg::State {});
+    assert_eq!(
+        res,
+        StateResponse {
+            total_ustake: Uint128::new(1000000),
+            total_uluna: Uint128::new(1037345),
+            exchange_rate: Decimal::from_ratio(1037345u128, 1000000u128),
+            unlocked_coins: vec![],
+        }
+    );
+}
+
+#[test]
 fn harvesting() {
     let mut deps = setup_test();
 

--- a/packages/eris-staking/src/hub.rs
+++ b/packages/eris-staking/src/hub.rs
@@ -37,6 +37,8 @@ pub enum ExecuteMsg {
     Bond {
         receiver: Option<String>,
     },
+    /// Donates specified amount of Luna to pool
+    Donate {},
     /// Withdraw Luna that have finished unbonding in previous batches
     WithdrawUnbonded {
         receiver: Option<String>,


### PR DESCRIPTION
donating possibility for the staking pool.
This allows us to use fees from other products to directly integrate and "donate" to the pool to increase the APY / exchange_rate of ampLUNA.